### PR TITLE
Publish action fix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -72,6 +72,6 @@ jobs:
       - name: Publish
         uses: softprops/action-gh-release@v2
         with:
-          files: "Chirp.Web*"
+          files: "Chirp.Razor*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,7 +61,7 @@ jobs:
           release_name="Chirp.Razor-$tag-${{ matrix.target }}"
 
           # Build everything
-          dotnet publish src/Chirp.Web/Chirp.Web.csproj --framework net7.0 --runtime "${{ matrix.target }}" --self-contained false -c Release -o "$release_name"
+          dotnet publish Chirp.sln --framework net7.0 --runtime "${{ matrix.target }}" --self-contained false -c Release -o "$release_name"
 
           # Pack files
           7z a -tzip "${release_name}.zip" "./${release_name}/*"

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -31,5 +31,9 @@
     <ProjectReference Include="..\Chirp.Infrastructure\Chirp.Infrastructure.csproj" />
     <ProjectReference Include="..\Chirp.Core\Chirp.Core.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <_EnableMacOSCodeSign>false</_EnableMacOSCodeSign>
+  </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
# Changed publish action, to publish the whole project.

* Disabled Code Signing on MacOS (See https://github.com/dotnet/sdk/issues/22201)