### PR TITLE
Fixing and improving navigation of cheep pages as per issue #143

### DIFF
--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -84,13 +84,17 @@
             }
         </ul>
         <div style="display: flex; justify-content: center;">
-
             @if (Model.page > 1)
             {
+                <button><a href="/?page=1">First Page</a></button>
                 <button style="margin-right: 17px"><a href="/?page=@(Model.page - 1)">Previous Page</a></button>
             }
-            <button><a href="/?page=@(Model.page + 1)">Next Page</a></button>
 
+            @if (Model.page < Model.pagesOfCheeps)
+            {
+                <button><a href="/?page=@(Model.page + 1)">Next Page</a></button>
+                <button><a href="/?page=@Model.pagesOfCheeps">Last Page</a></button>
+            }
         </div>
         <div><p>Page @Model.page of @Model.pagesOfCheeps</p></div>
     }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -105,9 +105,15 @@
 
                 @if (Model.page > 1)
                 {
+                    <button><a href="/@routeName?page=1">First Page</a></button>
                     <button style="margin-right: 17px"><a href="/@routeName?page=@(Model.page - 1)">Previous Page</a></button>
                 }
-                <button><a href="/@routeName?page=@(Model.page + 1)">Next Page</a></button>
+
+                @if (Model.page < Model.pagesOfCheeps)
+                {
+                    <button><a href="/@routeName?page=@(Model.page + 1)">Next Page</a></button> 
+                    <button><a href="/@routeName?page=@Model.pagesOfCheeps">Last Page</a></button>
+                }
             </div>
             <div><p>Page @Model.page of @Model.pagesOfCheeps</p></div>
 


### PR DESCRIPTION
Added a stopper for the next page only allowing users to see the pages as long as they are not on the last page,
also added a first and last page button only visible when applicable. 
This relates to issue #143  